### PR TITLE
Use rvalue-refs to avoid copies of FileInfo and FileSet objects.

### DIFF
--- a/src/stexecutor/rules_mappers/file_set.cc
+++ b/src/stexecutor/rules_mappers/file_set.cc
@@ -9,9 +9,9 @@
 
 namespace rules_mappers {
 
-FileSet::FileSet(const std::vector<FileInfo>& file_infos)
+FileSet::FileSet(std::vector<FileInfo>&& file_infos)
     : hash_value_(0),
-      sorted_file_infos_(file_infos) {
+      sorted_file_infos_(std::move(file_infos)) {
   std::sort(sorted_file_infos_.begin(), sorted_file_infos_.end());
   std::hash<std::string> string_hasher;
   for (const FileInfo& file_info : sorted_file_infos_) {

--- a/src/stexecutor/rules_mappers/file_set.h
+++ b/src/stexecutor/rules_mappers/file_set.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "boost/filesystem.hpp"
 #include "boost/serialization/serialization.hpp"
 #include "boost/serialization/vector.hpp"
 #include "stexecutor/rules_mappers/file_info.h"
@@ -18,9 +17,12 @@ namespace rules_mappers {
 // path to these files and hashes of content of each of them.
 class FileSet {
  public:
-  explicit FileSet(const std::vector<FileInfo>& file_infos);
+  explicit FileSet(std::vector<FileInfo>&& file_infos);
 
   FileSet();
+
+  FileSet(FileSet&&) = default;
+  FileSet& operator=(FileSet&&) = default;
 
   size_t hash_value() const {
     return hash_value_;
@@ -28,11 +30,13 @@ class FileSet {
 
   bool operator==(const FileSet& second) const;
 
-  const std::vector<FileInfo> file_infos() const {
+  const std::vector<FileInfo>& file_infos() const {
     return sorted_file_infos_;
   }
 
  private:
+  FileSet(const FileSet&) = delete;
+
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int version) {  // NOLINT

--- a/src/stexecutor/rules_mappers/in_memory_request_results.cc
+++ b/src/stexecutor/rules_mappers/in_memory_request_results.cc
@@ -22,10 +22,10 @@ log4cplus::Logger logger_ = log4cplus::Logger::getInstance(
 }  // namespace
 
 void InMemoryRequestResults::AddRule(
-    const std::vector<FileInfo>& input_files,
+    std::vector<FileInfo>&& input_files,
     std::unique_ptr<CachedExecutionResponse> response) {
-  FileSet file_set(input_files);
-  responses_[file_set] = std::move(response);
+  FileSet file_set(std::move(input_files));
+  responses_.emplace(std::move(file_set), std::move(response));
 }
 
 std::unique_ptr<CachedExecutionResponse>
@@ -37,8 +37,7 @@ InMemoryRequestResults::FindCachedResults(
         file_set_and_response.first,
         build_dir_state)) {
       *input_files = file_set_and_response.first.file_infos();
-      return std::unique_ptr<CachedExecutionResponse>(
-          new CachedExecutionResponse(*file_set_and_response.second));
+      return std::make_unique<CachedExecutionResponse>(*file_set_and_response.second);
     }
   }
   input_files->clear();

--- a/src/stexecutor/rules_mappers/in_memory_request_results.h
+++ b/src/stexecutor/rules_mappers/in_memory_request_results.h
@@ -24,7 +24,7 @@ struct CachedExecutionResponse;
 class InMemoryRequestResults : public RequestResultsBase {
  public:
   void AddRule(
-      const std::vector<FileInfo>& input_files,
+      std::vector<FileInfo>&& input_files,
       std::unique_ptr<CachedExecutionResponse> response) override;
   std::unique_ptr<CachedExecutionResponse> FindCachedResults(
       const BuildDirectoryState& build_dir_state,

--- a/src/stexecutor/rules_mappers/in_memory_rules_mapper.cc
+++ b/src/stexecutor/rules_mappers/in_memory_rules_mapper.cc
@@ -48,7 +48,7 @@ InMemoryRulesMapper::FindCachedResults(
 
 void InMemoryRulesMapper::AddRule(
     const ProcessCreationRequest& process_creation_request,
-    const std::vector<FileInfo>& input_files,
+    std::vector<FileInfo>&& input_files,
     std::unique_ptr<CachedExecutionResponse> response) {
   std::lock_guard<std::mutex> instance_lock(instance_lock_);
   HashValue request_hash = ComputeProcessCreationHash(
@@ -67,7 +67,7 @@ void InMemoryRulesMapper::AddRule(
     results = new_results.get();
     rules_.insert(std::make_pair(request_hash, std::move(new_results)));
   }
-  results->AddRule(input_files, std::move(response));
+  results->AddRule(std::move(input_files), std::move(response));
   if (!dbg_dump_rules_dir_.empty()) {
     DumpRequestResults(results, process_creation_request, request_hash);
   }

--- a/src/stexecutor/rules_mappers/in_memory_rules_mapper.h
+++ b/src/stexecutor/rules_mappers/in_memory_rules_mapper.h
@@ -29,7 +29,7 @@ class InMemoryRulesMapper : public RulesMapperBase {
       std::vector<FileInfo>* input_files) override;
   void AddRule(
       const ProcessCreationRequest& process_creation_request,
-      const std::vector<FileInfo>& input_files,
+      std::vector<FileInfo>&& input_files,
       std::unique_ptr<CachedExecutionResponse> response) override;
   void set_dbg_dump_rules_dir(
       const boost::filesystem::path& dbg_dump_rules_dir) {

--- a/src/stexecutor/rules_mappers/redis_request_results.cc
+++ b/src/stexecutor/rules_mappers/redis_request_results.cc
@@ -125,10 +125,10 @@ RedisRequestResults::RedisRequestResults(
 RedisRequestResults::~RedisRequestResults() {}
 
 void RedisRequestResults::AddRule(
-    const std::vector<FileInfo>& input_files,
+    std::vector<FileInfo>&& input_files,
     std::unique_ptr<CachedExecutionResponse> response) {
-  FileSet file_set(input_files);
-  HashValue input_files_hash = HashFileSet(file_set);
+  const FileSet file_set(std::move(input_files));
+  const HashValue input_files_hash = HashFileSet(file_set);
   std::string input_files_hash_string = HashValueToString(input_files_hash);
   SaveFileSet(FileSetHashToKey(input_files_hash_string), file_set);
   std::string key = RequestAndFileSetHashToKey(
@@ -217,7 +217,7 @@ bool RedisRequestResults::LoadFileSet(
       return false;
     file_infos.push_back(info);
   }
-  *file_set = FileSet(file_infos);
+  *file_set = FileSet(std::move(file_infos));
   return true;
 }
 

--- a/src/stexecutor/rules_mappers/redis_request_results.h
+++ b/src/stexecutor/rules_mappers/redis_request_results.h
@@ -30,7 +30,7 @@ class RedisRequestResults : public RequestResultsBase {
       const HashValue& request_hash);
   ~RedisRequestResults();
   void AddRule(
-      const std::vector<FileInfo>& input_files,
+      std::vector<FileInfo>&& input_files,
       std::unique_ptr<CachedExecutionResponse> response) override;
   std::unique_ptr<CachedExecutionResponse> FindCachedResults(
       const BuildDirectoryState& build_dir_state,

--- a/src/stexecutor/rules_mappers/redis_rules_mapper.cc
+++ b/src/stexecutor/rules_mappers/redis_rules_mapper.cc
@@ -44,7 +44,7 @@ RedisRulesMapper::FindCachedResults(
 
 void RedisRulesMapper::AddRule(
     const ProcessCreationRequest& process_creation_request,
-    const std::vector<FileInfo>& input_files,
+    std::vector<FileInfo>&& input_files,
     std::unique_ptr<CachedExecutionResponse> response) {
   HashValue request_hash = ComputeProcessCreationHash(
       process_creation_request);
@@ -52,7 +52,7 @@ void RedisRulesMapper::AddRule(
      redis_client_pool_->GetClient(RedisClientType::READ_WRITE);
   std::unique_ptr<RedisRequestResults> results(
       new RedisRequestResults(redis_client_holder.client(), request_hash));
-  results->AddRule(input_files, std::move(response));
+  results->AddRule(std::move(input_files), std::move(response));
 }
 
 }  // namespace rules_mappers

--- a/src/stexecutor/rules_mappers/redis_rules_mapper.h
+++ b/src/stexecutor/rules_mappers/redis_rules_mapper.h
@@ -28,7 +28,7 @@ class RedisRulesMapper : public RulesMapperBase {
       std::vector<FileInfo>* input_files) override;
   void AddRule(
       const ProcessCreationRequest& process_creation_request,
-      const std::vector<FileInfo>& input_files,
+      std::vector<FileInfo>&& input_files,
       std::unique_ptr<CachedExecutionResponse> response) override;
 
  private:

--- a/src/stexecutor/rules_mappers/request_results_base.h
+++ b/src/stexecutor/rules_mappers/request_results_base.h
@@ -20,7 +20,7 @@ class RequestResultsBase {
  public:
   virtual ~RequestResultsBase();
   virtual void AddRule(
-      const std::vector<FileInfo>& input_files,
+      std::vector<FileInfo>&& input_files,
       std::unique_ptr<CachedExecutionResponse> response) = 0;
   virtual std::unique_ptr<CachedExecutionResponse> FindCachedResults(
       const BuildDirectoryState& build_dir_state,

--- a/src/stexecutor/rules_mappers/rules_mapper.h
+++ b/src/stexecutor/rules_mappers/rules_mapper.h
@@ -26,7 +26,7 @@ class RulesMapper {
       std::vector<FileInfo>* input_files) = 0;
   virtual void AddRule(
       const ProcessCreationRequest& process_creation_request,
-      const std::vector<FileInfo>& input_files,
+      std::vector<FileInfo>&& input_files,
       std::unique_ptr<CachedExecutionResponse> response) = 0;
 };
 


### PR DESCRIPTION
This PR should prevent from copying some heavy objects with dynamic allocations.
All temporary objects should be moved to its final destination.
No behaviour changes expected (aside from decreasing memory footprint and speed-up).
PTAL.